### PR TITLE
fix: Fixed macro redefinition when compiling on Windows x86-64 & arm64.

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -2,7 +2,6 @@ name: Build and Release
 
 on:
   push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:

--- a/include/logger/Colors.h
+++ b/include/logger/Colors.h
@@ -2,46 +2,46 @@
 #define LOGGER_COLORS_H
 
 // Reset
-#define COLOR_RESET                "\033[0m"
+#define SHUVLOG_RST             "\033[0m"
 
-// Standard Foreground Colors
-#define COLOR_BLACK                "\033[30m"
-#define COLOR_RED                  "\033[31m"
-#define COLOR_GREEN                "\033[32m"
-#define COLOR_YELLOW               "\033[33m"
-#define COLOR_BLUE                 "\033[34m"
-#define COLOR_MAGENTA              "\033[35m"
-#define COLOR_CYAN                 "\033[36m"
-#define COLOR_WHITE                "\033[37m"
+// Foreground colors
+#define SHUVLOG_FG_BLACK        "\033[30m"
+#define SHUVLOG_FG_RED          "\033[31m"
+#define SHUVLOG_FG_GREEN        "\033[32m"
+#define SHUVLOG_FG_YELLOW       "\033[33m"
+#define SHUVLOG_FG_BLUE         "\033[34m"
+#define SHUVLOG_FG_MAGENTA      "\033[35m"
+#define SHUVLOG_FG_CYAN         "\033[36m"
+#define SHUVLOG_FG_WHITE        "\033[37m"
 
-// Bright Foreground Colors
-#define COLOR_BRIGHT_BLACK         "\033[90m"
-#define COLOR_BRIGHT_RED           "\033[91m"
-#define COLOR_BRIGHT_GREEN         "\033[92m"
-#define COLOR_BRIGHT_YELLOW        "\033[93m"
-#define COLOR_BRIGHT_BLUE          "\033[94m"
-#define COLOR_BRIGHT_MAGENTA       "\033[95m"
-#define COLOR_BRIGHT_CYAN          "\033[96m"
-#define COLOR_BRIGHT_WHITE         "\033[97m"
+// Bright foreground colors
+#define SHUVLOG_FG_BR_BLACK     "\033[90m"
+#define SHUVLOG_FG_BR_RED       "\033[91m"
+#define SHUVLOG_FG_BR_GREEN     "\033[92m"
+#define SHUVLOG_FG_BR_YELLOW    "\033[93m"
+#define SHUVLOG_FG_BR_BLUE      "\033[94m"
+#define SHUVLOG_FG_BR_MAGENTA   "\033[95m"
+#define SHUVLOG_FG_BR_CYAN      "\033[96m"
+#define SHUVLOG_FG_BR_WHITE     "\033[97m"
 
-// Standard Background Colors
-#define BACKGROUND_BLACK           "\033[40m"
-#define BACKGROUND_RED             "\033[41m"
-#define BACKGROUND_GREEN           "\033[42m"
-#define BACKGROUND_YELLOW          "\033[43m"
-#define BACKGROUND_BLUE            "\033[44m"
-#define BACKGROUND_MAGENTA         "\033[45m"
-#define BACKGROUND_CYAN            "\033[46m"
-#define BACKGROUND_WHITE           "\033[47m"
+// Background colors
+#define SHUVLOG_BG_BLACK        "\033[40m"
+#define SHUVLOG_BG_RED          "\033[41m"
+#define SHUVLOG_BG_GREEN        "\033[42m"
+#define SHUVLOG_BG_YELLOW       "\033[43m"
+#define SHUVLOG_BG_BLUE         "\033[44m"
+#define SHUVLOG_BG_MAGENTA      "\033[45m"
+#define SHUVLOG_BG_CYAN         "\033[46m"
+#define SHUVLOG_BG_WHITE        "\033[47m"
 
-// Bright Background Colors
-#define BACKGROUND_BRIGHT_BLACK    "\033[100m"
-#define BACKGROUND_BRIGHT_RED      "\033[101m"
-#define BACKGROUND_BRIGHT_GREEN    "\033[102m"
-#define BACKGROUND_BRIGHT_YELLOW   "\033[103m"
-#define BACKGROUND_BRIGHT_BLUE     "\033[104m"
-#define BACKGROUND_BRIGHT_MAGENTA  "\033[105m"
-#define BACKGROUND_BRIGHT_CYAN     "\033[106m"
-#define BACKGROUND_BRIGHT_WHITE    "\033[107m"
+// Bright background colors
+#define SHUVLOG_BG_BR_BLACK     "\033[100m"
+#define SHUVLOG_BG_BR_RED       "\033[101m"
+#define SHUVLOG_BG_BR_GREEN     "\033[102m"
+#define SHUVLOG_BG_BR_YELLOW    "\033[103m"
+#define SHUVLOG_BG_BR_BLUE      "\033[104m"
+#define SHUVLOG_BG_BR_MAGENTA   "\033[105m"
+#define SHUVLOG_BG_BR_CYAN      "\033[106m"
+#define SHUVLOG_BG_BR_WHITE     "\033[107m"
 
-#endif
+#endif // LOGGER_COLORS_H

--- a/include/logger/Level.h
+++ b/include/logger/Level.h
@@ -64,15 +64,15 @@ namespace level
     {
         switch (level) {
             using enum Level;
-            case kDebug:    return COLOR_BRIGHT_BLUE;
-            case kTraceR3:  return COLOR_BRIGHT_BLACK;
-            case kTraceR2:  return COLOR_GREEN;
-            case kTraceR1:  return COLOR_CYAN;
-            case kWarning:  return COLOR_YELLOW;
-            case kError:    return COLOR_RED;
-            case kCritical: return COLOR_MAGENTA;
-            case kFatal:    return BACKGROUND_RED;
-            default: return "";
+            case kDebug:    return SHUVLOG_FG_BR_BLUE;
+            case kTraceR3:  return SHUVLOG_FG_BR_BLACK;
+            case kTraceR2:  return SHUVLOG_FG_GREEN;
+            case kTraceR1:  return SHUVLOG_FG_CYAN;
+            case kWarning:  return SHUVLOG_FG_YELLOW;
+            case kError:    return SHUVLOG_FG_RED;
+            case kCritical: return SHUVLOG_FG_MAGENTA;
+            case kFatal:    return SHUVLOG_BG_RED;
+            default:        return "";
         }
     }
 

--- a/src/Sinks/ConsoleSink.cpp
+++ b/src/Sinks/ConsoleSink.cpp
@@ -112,7 +112,7 @@ void ConsoleSink::write(const Log& log)
     out << output;
 
     if (_useColors) {
-        out << COLOR_RESET;
+        out << SHUVLOG_RST;
     }
 }
 


### PR DESCRIPTION
<img width="1206" height="663" alt="Screenshot 2025-12-14 at 11 11 45 PM" src="https://github.com/user-attachments/assets/7aa69d4e-e36c-42cf-bf03-d540f411780c" />
No more redefinition!!